### PR TITLE
Fix initialization on OS X

### DIFF
--- a/src/Fontconfig.jl
+++ b/src/Fontconfig.jl
@@ -7,22 +7,21 @@ if Pkg.installed("Homebrew") != nothing
 end
 
 function __init__()
-    ccall((:FcInit, :libfontconfig), Uint8, ())
 
     @osx_only begin
         if Pkg.installed("Homebrew") != nothing
             if Homebrew.installed("fontconfig")
-                function __init__()
-                    ENV["PANGO_SYSCONFDIR"] = joinpath(Homebrew.prefix(), "etc", "fonts", "fonts.conf")
-                end
+                ENV["FONTCONFIG_FILE"] = joinpath(Homebrew.prefix(), "etc", "fonts", "fonts.conf")
             end
         end
-
-        # By default fontconfig on OSX does not include user fonts.
-        ccall((:FcConfigAppFontAddDir, :libfontconfig),
-              Uint8, (Ptr{Void}, Ptr{Uint8}),
-              C_NULL, b"~/Library/Fonts")
     end
+
+    ccall((:FcInit, :libfontconfig), Uint8, ())
+
+    # By default fontconfig on OSX does not include user fonts.
+    @osx_only ccall((:FcConfigAppFontAddDir, :libfontconfig),
+                      Uint8, (Ptr{Void}, Ptr{Uint8}),
+                      C_NULL, b"~/Library/Fonts")
 end
 
 


### PR DESCRIPTION
Just a few minor adjustments to get things working here.  The FONTCONFIG_FILE variable must be set before ccalling FcInit.

From trial and error, it doesn't seem to make a difference whether I add the local fonts directory before or after calling FcInit, but doing it afterwards feels better.
