### PR TITLE
Set `ENV["FONTCONFIG_FILE"]` within Homebrew `onload` hook

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,8 @@ fontconfig = library_dependency("fontconfig", aliases = ["libfontconfig-1", "lib
 if is_apple()
     using Homebrew
     provides(Homebrew.HB, "freetype", freetype, os = :Darwin)
-    provides(Homebrew.HB, "fontconfig", fontconfig, os = :Darwin)
+    FONTCONFIG_FILE = joinpath(Homebrew.prefix(), "etc", "fonts", "fonts.conf")
+    provides(Homebrew.HB, "fontconfig", fontconfig, os = :Darwin, onload="const FONTCONFIG_FILE = \"$FONTCONFIG_FILE\"\n")
 end
 
 if is_windows()

--- a/src/Fontconfig.jl
+++ b/src/Fontconfig.jl
@@ -11,17 +11,13 @@ else
 end
 
 using Compat
-@static if is_apple()
-    using Homebrew
-end
 
 export format, match, list
 
 function __init__()
-    @static if is_apple()
-        ENV["FONTCONFIG_FILE"] = joinpath(Homebrew.prefix(), "etc", "fonts", "fonts.conf")
+    if isdefined(Fontconfig, :FONTCONFIG_FILE)
+        ENV["FONTCONFIG_FILE"] = FONTCONFIG_FILE
     end
-
     ccall((:FcInit, jl_libfontconfig), UInt8, ())
 
     # By default fontconfig on OSX does not include user fonts.


### PR DESCRIPTION
This causes the environment variable to be set only when `Homebrew.jl` is actually providing Fontconfig, which should fix #13  when something other than `Homebrew.jl` is providing the fontconfig library.

Note I haven't tested this, so this code might need some tweaking.

