### PR TITLE
Customize properties returned in `list`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Fontconfig"
 uuid = "186bb1d3-e1f7-5a2c-a377-96d770f13627"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Fontconfig_jll = "a3f928ae-7b40-5064-980b-68af3947d34b"

--- a/src/Fontconfig.jl
+++ b/src/Fontconfig.jl
@@ -132,7 +132,13 @@ struct FcFontSet
 end
 
 
-function list(pat::Pattern=Pattern())
+"""
+    list(pat::Pattern=Pattern(), properties = ["family", "style", "file"])::Vector{Pattern}
+    
+Selects fonts matching `pat` and creates patterns from those fonts. These patterns containing only those 
+properties listed in `properties`, and returns a vector of unique such patterns, as a `Vector{Pattern}`.
+"""
+function list(pat::Pattern=Pattern(), properties = ["family", "style", "file"])
     os = ccall((:FcObjectSetCreate, libfontconfig), Ptr{Nothing}, ())
     ccall((:FcObjectSetAdd, libfontconfig), Cint, (Ptr{Nothing}, Ptr{UInt8}),
           os, "family")

--- a/src/Fontconfig.jl
+++ b/src/Fontconfig.jl
@@ -140,12 +140,10 @@ properties listed in `properties`, and returns a vector of unique such patterns,
 """
 function list(pat::Pattern=Pattern(), properties = ["family", "style", "file"])
     os = ccall((:FcObjectSetCreate, libfontconfig), Ptr{Nothing}, ())
-    ccall((:FcObjectSetAdd, libfontconfig), Cint, (Ptr{Nothing}, Ptr{UInt8}),
-          os, "family")
-    ccall((:FcObjectSetAdd, libfontconfig), Cint, (Ptr{Nothing}, Ptr{UInt8}),
-          os, "style")
-    ccall((:FcObjectSetAdd, libfontconfig), Cint, (Ptr{Nothing}, Ptr{UInt8}),
-          os, "file")
+    for property in properties
+        ccall((:FcObjectSetAdd, libfontconfig), Cint, (Ptr{Nothing}, Ptr{UInt8}),
+              os, property)
+    end
 
     fs_ptr = ccall((:FcFontList, libfontconfig), Ptr{FcFontSet},
                    (Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}), C_NULL, pat.ptr, os)


### PR DESCRIPTION
This is useful for e.g. Freetype integration, where one may want to load a list object directly into a FreeType font - this necessitates either the index of the font or its direct `ftface` parameter.  This change allows both.